### PR TITLE
Set service type to ClusterIP in template

### DIFF
--- a/helm/loadtest-app-chart/templates/service.yaml
+++ b/helm/loadtest-app-chart/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.type }}
+  type: ClusterIP
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/helm/loadtest-app-chart/values.yaml
+++ b/helm/loadtest-app-chart/values.yaml
@@ -8,7 +8,6 @@ image:
   pullPolicy: IfNotPresent
 
 service:
-  type: ClusterIP
   port: 9000
 
 ingress:


### PR DESCRIPTION
I got a template error about the service type when it tried to install the chart in the e2e test.

For now just moving ClusterIP to the template.

```
{"caller":"github.com/giantswarm/aws-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:350","level":"debug","message":"err string: `rpc error: code = Unknown desc = render error in \"loadtest-app-chart/templates/service.yaml\": template: loadtest-app-chart/templates/service.yaml:11:18: executing \"loadtest-app-chart/templates/service.yaml\" at \u003c.Values.service.type\u003e: can't evaluate field type in type interface {}`","time":"2019-06-26T15:52:26.061812+00:00"}
```