### PR TITLE
Use Always image pull policy due to latest tag

### DIFF
--- a/helm/loadtest-app/values.yaml
+++ b/helm/loadtest-app/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: stormforger/testapp
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 service:
   port: 8080


### PR DESCRIPTION
See the notes under https://kubernetes.io/docs/concepts/configuration/overview/#container-images