### PR TITLE
Use networking Ingress API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `networking.k8s.io/v1beta1` instead of `extensions/v1beta1` Ingress API.
+
 ## [0.2.0] - 2020-08-11
 
 ### Changed

--- a/helm/loadtest-app/templates/ingress.yaml
+++ b/helm/loadtest-app/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "testapp-chart.fullname" . -}}
 {{- $ingressPaths := .Values.ingress.paths -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
NGINX IC 0.40.0 drops support for validating `extensions/v1beta1` Ingress resources. Validating webhook is enabled by default in NGINX IC App. Although it's not absolutely necessary to have validating webhook enabled in performance tests, it helps to have it enabled for both ensuring load test initial state correctness and also serves as functional integration test.
Some more details in https://github.com/giantswarm/nginx-ingress-controller-app/pull/122 and changelog.

Assuming this gets merged and released, @piontec I'll need your help to update dependency and release https://github.com/giantswarm/pytest-helm-charts