### PR TITLE
Fixup labels on Deployment and HPA

### DIFF
--- a/helm/loadtest-app/templates/deployment.yaml
+++ b/helm/loadtest-app/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ .Values.name }}
     helm.sh/chart: {{ include "testapp-chart.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Values.managed_by }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/helm/loadtest-app/templates/hpa.yaml
+++ b/helm/loadtest-app/templates/hpa.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ .Values.name }}
     helm.sh/chart: {{ include "testapp-chart.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Values.managed_by }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/helm/loadtest-app/values.yaml
+++ b/helm/loadtest-app/values.yaml
@@ -1,5 +1,3 @@
-managed-by: giantswarm
-
 name: loadtest-app
 
 replicaCount: 1


### PR DESCRIPTION
The `app.kubernetes.io/managed-by` label value referred to
`.Values.managed_by` variable which is undefined (possibly a typo for
`managed-by`) which caused an error when templating the chart.

Instead make the label refer to `.Release.Service` which is consistent
with the `Ingress` and `Service` resources and compliant with Helm
recommendations.